### PR TITLE
tuxsuite-postprocess: support to pass reference build urls

### DIFF
--- a/projects/lkft-android/include/tuxsuite-postprocess.jinja2
+++ b/projects/lkft-android/include/tuxsuite-postprocess.jinja2
@@ -9,15 +9,35 @@
 {% set opt_build_config_url = "" %}
 {% endif %}
 
+{% if BUILD_REFERENCE_IMAGE_GZ_URL is defined %}
+{% set opt_image_gz_url = "-k " + BUILD_REFERENCE_IMAGE_GZ_URL %}
+{% else %}
+{% set opt_image_gz_url = "" %}
+{% endif %}
+
+{% if TUXSUITE_BAKE_VENDOR_DOWNLOAD_URL is defined %}
+{% set opt_tuxsuite_download_url = "-v " + TUXSUITE_BAKE_VENDOR_DOWNLOAD_URL %}
+{% else %}
+{% set opt_tuxsuite_download_url = "" %}
+{% endif %}
+
+{% if REFERENCE_BUILD_URL is defined %}
+{% set opt_reference_url = "-ru " + REFERENCE_BUILD_URL %}
+{% else %}
+{% set opt_reference_url = "" %}
+{% endif %}
+
+{% if REFERENCE_BUILD_URL_GSI is defined %}
+{% set opt_reference_url_gsi = "-rug " + REFERENCE_BUILD_URL_GSI %}
+{% else %}
+{% set opt_reference_url_gsi = "" %}
+{% endif %}
+
 {% if TUXSUITE_BAKE_VENDOR_DOWNLOAD_URL is defined %}
     postprocess:
         docker:
-            image: linaro/lava-android-postprocess:bulleye-2023.09.14-01
+            image: linaro/lava-android-postprocess:bullseye-2024.03.13-01
             local: true
             steps:
-{% if BUILD_REFERENCE_IMAGE_GZ_URL is defined %}
-            - linaro-lkft-android.sh -g -k {{BUILD_REFERENCE_IMAGE_GZ_URL}} -v {{TUXSUITE_BAKE_VENDOR_DOWNLOAD_URL}} -c {{LKFT_BUILD_CONFIG}} {{opt_build_config_url}}
-{% else %}
-            - linaro-lkft-android.sh -g -v {{TUXSUITE_BAKE_VENDOR_DOWNLOAD_URL}} -c {{LKFT_BUILD_CONFIG}} {{opt_build_config_url}}
-{% endif %}
+            - linaro-lkft-android.sh -g {{opt_image_gz_url}} {{opt_tuxsuite_download_url}} {{opt_reference_url}} {{opt_reference_url_gsi}} -c {{LKFT_BUILD_CONFIG}} {{opt_build_config_url}}
 {% endif %}


### PR DESCRIPTION
to make sure the specified reference build will be used when the jobs is run, no matter when the job defintion was generated and wehn the job will be run